### PR TITLE
Update order 26

### DIFF
--- a/src/courses/courses.controller.ts
+++ b/src/courses/courses.controller.ts
@@ -539,7 +539,7 @@ export default class CoursesController implements IController {
           orders.push(chapter.order);
         });
 
-        const order = orders.length > 0 ? Math.max(...orders) + 1 : 0;
+        const order = orders.length > 0 ? Math.max(...orders) + 1 : 1;
 
         const result = await this.chaptersService.createChapter({
           where: {
@@ -716,7 +716,7 @@ export default class CoursesController implements IController {
             orders.push(lecture.order);
           });
 
-          const order = orders.length > 0 ? Math.max(...orders) + 1 : 0;
+          const order = orders.length > 0 ? Math.max(...orders) + 1 : 1;
 
           // req.file이 있을 경우
           if (req.file) {
@@ -863,7 +863,7 @@ export default class CoursesController implements IController {
               orders.push(lecture.order);
             });
 
-            order = orders.length > 0 ? Math.max(...orders) + 1 : 0;
+            order = orders.length > 0 ? Math.max(...orders) + 1 : 1;
           }
 
           const data = new UpdateLectureData({

--- a/src/courses/courses.controller.ts
+++ b/src/courses/courses.controller.ts
@@ -585,13 +585,17 @@ export default class CoursesController implements IController {
           return chapter.id;
         });
 
-        if (!(data.chapters.length === chapter_records_ids.length)) {
+        if (data.chapters.length !== chapter_records_ids.length) {
           throw new CustomError('잘못된 값이 입력되었습니다.');
         }
         if (
-          ![...data.chapters].sort().every(function (value, index) {
-            return value === [...chapter_records_ids].sort()[index];
-          })
+          ![...data.chapters]
+            .sort((a, b) => a - b)
+            .every(function (value, index) {
+              return (
+                value === [...chapter_records_ids].sort((a, b) => a - b)[index]
+              );
+            })
         ) {
           throw new CustomError('잘못된 값이 입력되었습니다.');
         }
@@ -790,14 +794,19 @@ export default class CoursesController implements IController {
             return lecture.id;
           });
 
-          if (!(data.lectures.length === lecture_records_ids.length)) {
+          if (data.lectures.length !== lecture_records_ids.length) {
             throw new CustomError('잘못된 값이 입력되었습니다.');
           }
 
           if (
-            ![...data.lectures].sort().every(function (value, index) {
-              return value === [...lecture_records_ids].sort()[index];
-            })
+            ![...data.lectures]
+              .sort((a, b) => a - b)
+              .every(function (value, index) {
+                return (
+                  value ===
+                  [...lecture_records_ids].sort((a, b) => a - b)[index]
+                );
+              })
           ) {
             throw new CustomError('잘못된 값이 입력되었습니다.');
           }
@@ -859,7 +868,7 @@ export default class CoursesController implements IController {
 
             const orders: number[] = [];
 
-            lectures.map((lecture) => {
+            lectures.forEach((lecture) => {
               orders.push(lecture.order);
             });
 

--- a/src/courses/dtos/chapters.dto.ts
+++ b/src/courses/dtos/chapters.dto.ts
@@ -1,9 +1,15 @@
-import { IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsArray, IsNumber, IsString } from 'class-validator';
 import { FindOptionsSelect } from 'typeorm';
 import Chapter from '../entities/chapter.entity';
 
 export class FindChaptersByCourseId {
   course_id: number;
+  select?: FindOptionsSelect<Chapter>;
+}
+
+export class FindChapterByChapterAndCourseId {
+  course_id: number;
+  chapter_id: number;
   select?: FindOptionsSelect<Chapter>;
 }
 
@@ -27,18 +33,27 @@ export class CreateChapterDTO {
 }
 
 export class UpdateChapterData {
-  constructor({ title, order }: UpdateChapterData) {
-    if (title) this.title = title;
-    if (order) this.order = order;
+  constructor({ title }: UpdateChapterData) {
+    this.title = title;
   }
 
   @IsString()
-  @IsOptional()
-  title?: string;
+  title: string;
+}
 
-  @IsNumber()
-  @IsOptional()
-  order?: number;
+export class UpdateChaptersOrderData {
+  constructor({ chapters }: UpdateChaptersOrderData) {
+    this.chapters = chapters;
+  }
+
+  @IsArray()
+  @IsNumber({}, { each: true })
+  chapters: number[];
+}
+
+export class UpdateChapterOrdersDTO {
+  teacher_id: number;
+  data: UpdateChaptersOrderData;
 }
 
 export class UpdateChapterDTO {

--- a/src/courses/dtos/courses.dto.ts
+++ b/src/courses/dtos/courses.dto.ts
@@ -11,13 +11,36 @@ import { FindOptionsSelect } from 'typeorm';
 import Course from '../entities/course.entity';
 
 export class CreateCourseData {
+  constructor({ category_id, title, description, level }: CreateCourseData) {
+    this.category_id = category_id;
+    this.description = description;
+    this.level = level;
+    this.title = title;
+  }
+
+  @IsNumber()
+  category_id: number;
+
+  @IsString()
+  title: string;
+
+  @IsString()
+  description: string;
+
+  @IsInt()
+  @Max(5)
+  @Min(1)
+  level: number;
+}
+
+export class CreateCourseDataWithCoverImage {
   constructor({
     category_id,
     title,
     description,
     level,
     cover_image,
-  }: CreateCourseData) {
+  }: CreateCourseDataWithCoverImage) {
     this.category_id = category_id;
     this.cover_image = cover_image;
     this.description = description;
@@ -45,19 +68,12 @@ export class CreateCourseData {
 
 export class CreateCourseDTO {
   teacher_id: number;
-  data: CreateCourseData;
+  data: CreateCourseDataWithCoverImage;
 }
 
 export class UpdateCourseData {
-  constructor({
-    category_id,
-    title,
-    description,
-    level,
-    cover_image,
-  }: UpdateCourseData) {
+  constructor({ category_id, title, description, level }: UpdateCourseData) {
     if (category_id) this.category_id = category_id;
-    if (cover_image) this.cover_image = cover_image;
     if (description) this.description = description;
     if (level) this.level = level;
     if (title) this.title = title;
@@ -80,10 +96,43 @@ export class UpdateCourseData {
   @Min(1)
   @IsOptional()
   level?: number;
+}
+
+export class UpdateCourseDataWithCoverImage {
+  constructor({
+    category_id,
+    title,
+    description,
+    level,
+    cover_image,
+  }: UpdateCourseDataWithCoverImage) {
+    if (category_id) this.category_id = category_id;
+    if (description) this.description = description;
+    if (level) this.level = level;
+    if (title) this.title = title;
+    this.cover_image = cover_image;
+  }
+
+  @IsNumber()
+  @IsOptional()
+  category_id?: number;
+
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsInt()
+  @Max(5)
+  @Min(1)
+  @IsOptional()
+  level?: number;
 
   @IsUrl()
-  @IsOptional()
-  cover_image?: string;
+  cover_image: string;
 }
 
 export class UpdateCourseDTO {
@@ -92,6 +141,14 @@ export class UpdateCourseDTO {
     teacher_id: number;
   };
   data: UpdateCourseData;
+}
+
+export class UpdateCourseWithCoverImageDTO {
+  where: {
+    id: number;
+    teacher_id: number;
+  };
+  data: UpdateCourseDataWithCoverImage;
 }
 
 export class FindAllCoursesDTO {

--- a/src/courses/dtos/lectures.dto.ts
+++ b/src/courses/dtos/lectures.dto.ts
@@ -4,6 +4,7 @@ import {
   IsUrl,
   IsOptional,
   IsBoolean,
+  IsArray,
 } from 'class-validator';
 import { FindOptionsSelect } from 'typeorm';
 import Lecture from '../entities/lecture.entity';
@@ -31,16 +32,39 @@ export class FindLectureByIdDTO {
 }
 
 export class CreateLectureData {
+  constructor({ chapter_id, title, content, is_public }: CreateLectureData) {
+    this.chapter_id = chapter_id;
+    this.title = title;
+    if (content) this.content = content;
+    if (is_public) this.is_public = is_public;
+  }
+
+  @IsNumber()
+  chapter_id: number;
+
+  @IsString()
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  content?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  is_public?: boolean;
+}
+
+export class CreateLectureDataWithVideoUrl {
   constructor({
     chapter_id,
     title,
     video_url,
     content,
     is_public,
-  }: CreateLectureData) {
+  }: CreateLectureDataWithVideoUrl) {
     this.chapter_id = chapter_id;
     this.title = title;
-    if (video_url) this.video_url = video_url;
+    this.video_url = video_url;
     if (content) this.content = content;
     if (is_public) this.is_public = is_public;
   }
@@ -52,8 +76,7 @@ export class CreateLectureData {
   title: string;
 
   @IsUrl()
-  @IsOptional()
-  video_url?: string;
+  video_url: string;
 
   @IsString()
   @IsOptional()
@@ -73,21 +96,65 @@ export class CreateLectureDTO {
   data: CreateLectureData;
 }
 
+export class CreateLectureWithVideoUrlDTO {
+  where: {
+    teacher_id: number;
+    course_id: number;
+    order: number;
+  };
+  data: CreateLectureDataWithVideoUrl;
+}
+
 export class UpdateLectureData {
+  constructor({
+    chapter_id,
+    title,
+    content,
+    is_public,
+    order,
+  }: UpdateLectureData) {
+    if (chapter_id) this.chapter_id = chapter_id;
+    if (title) this.title = title;
+    if (content) this.content = content;
+    if (is_public) this.is_public = is_public;
+    if (order || order === 0) this.order = order;
+  }
+
+  @IsNumber()
+  @IsOptional()
+  chapter_id?: number;
+
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  content?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  is_public?: boolean;
+
+  @IsNumber()
+  @IsOptional()
+  order?: number;
+}
+export class UpdateLectureDataWithVideUrl {
   constructor({
     chapter_id,
     title,
     video_url,
     content,
-    order,
     is_public,
-  }: UpdateLectureData) {
+    order,
+  }: UpdateLectureDataWithVideUrl) {
+    this.video_url = video_url;
     if (chapter_id) this.chapter_id = chapter_id;
     if (title) this.title = title;
-    if (order) this.order = order;
-    if (video_url) this.video_url = video_url;
     if (content) this.content = content;
     if (is_public) this.is_public = is_public;
+    if (order) this.order = order;
   }
 
   @IsNumber()
@@ -99,20 +166,19 @@ export class UpdateLectureData {
   title?: string;
 
   @IsUrl()
-  @IsOptional()
-  video_url?: string;
+  video_url: string;
 
   @IsString()
   @IsOptional()
   content?: string;
 
-  @IsNumber()
-  @IsOptional()
-  order?: number;
-
   @IsBoolean()
   @IsOptional()
   is_public?: boolean;
+
+  @IsNumber()
+  @IsOptional()
+  order?: number;
 }
 
 export class UpdateLectureDTO {
@@ -120,9 +186,24 @@ export class UpdateLectureDTO {
   data: UpdateLectureData;
 }
 
-export class UpdateChapterlessLecutreDTO {
-  chapter_id: number;
+export class UpdateLectureWithVideoUrlDTO {
+  where: { id: number; teacher_id: number; course_id: number };
+  data: UpdateLectureDataWithVideUrl;
+}
+
+export class UpdateLecturesOrderData {
+  constructor({ lectures }: UpdateLecturesOrderData) {
+    this.lectures = lectures;
+  }
+
+  @IsArray()
+  @IsNumber({}, { each: true })
+  lectures: number[];
+}
+
+export class UpdateLectureOrdersDTO {
   teacher_id: number;
+  data: UpdateLecturesOrderData;
 }
 
 export class DeleteLectureDTO {

--- a/src/courses/dtos/lectures.dto.ts
+++ b/src/courses/dtos/lectures.dto.ts
@@ -117,7 +117,7 @@ export class UpdateLectureData {
     if (title) this.title = title;
     if (content) this.content = content;
     if (is_public) this.is_public = is_public;
-    if (order || order === 0) this.order = order;
+    if (order) this.order = order;
   }
 
   @IsNumber()

--- a/src/courses/services/chapters.service.ts
+++ b/src/courses/services/chapters.service.ts
@@ -7,7 +7,9 @@ import {
   DeleteChaptersDTO,
   DeleteChapterDTO,
   FindChaptersByCourseId,
+  FindChapterByChapterAndCourseId,
   UpdateChapterDTO,
+  UpdateChapterOrdersDTO,
 } from '../dtos/chapters.dto';
 
 export default class ChaptersService implements IService {
@@ -28,6 +30,19 @@ export default class ChaptersService implements IService {
     return result;
   }
 
+  async findChapterByChapterAndCourseId({
+    chapter_id,
+    course_id,
+    select,
+  }: FindChapterByChapterAndCourseId): Promise<Chapter> {
+    const result = await this.chapterRepository.findOne({
+      where: { id: chapter_id, course_id },
+      ...(select && { select }),
+    });
+    if (!result) throw new CustomError('해당 챕터가 코스에 존재하지 않습니다.');
+    return result;
+  }
+
   async createChapter({ where, data }: CreateChapterDTO): Promise<Chapter> {
     const result = await this.chapterRepository.save(
       this.chapterRepository.create({ ...where, ...data }),
@@ -43,6 +58,28 @@ export default class ChaptersService implements IService {
     }
     const result = await this.chapterRepository.save(chapter);
     return result;
+  }
+  async updateChapterOrders({
+    teacher_id,
+    data,
+  }: UpdateChapterOrdersDTO): Promise<number[]> {
+    const chpters = data.chapters;
+
+    await this.chapterRepository.manager.transaction(
+      'SERIALIZABLE',
+      async (transactionalEntityManager) => {
+        for (let i = 0; i < chpters.length; i++) {
+          const chapter = await this.chapterRepository.findOne({
+            where: { teacher_id, id: chpters[i] },
+          });
+
+          if (!chapter) throw new CustomError('챕터가 존재하지 않습니다.');
+          chapter.order = i;
+          await transactionalEntityManager.save(chapter);
+        }
+      },
+    );
+    return chpters;
   }
   async deleteChapter(dto: DeleteChapterDTO): Promise<DeleteChapterDTO> {
     await this.chapterRepository.delete(dto);

--- a/src/courses/services/chapters.service.ts
+++ b/src/courses/services/chapters.service.ts
@@ -74,7 +74,7 @@ export default class ChaptersService implements IService {
           });
 
           if (!chapter) throw new CustomError('챕터가 존재하지 않습니다.');
-          chapter.order = i;
+          chapter.order = i + 1;
           await transactionalEntityManager.save(chapter);
         }
       },

--- a/src/courses/services/courses.service.ts
+++ b/src/courses/services/courses.service.ts
@@ -6,6 +6,7 @@ import {
   FindCoursesByIdsDTO,
   FindCoursesByQueryDTO,
   FindCoursesByTeacherIdDTO,
+  UpdateCourseWithCoverImageDTO,
 } from '@/courses/dtos/courses.dto';
 import { CreateCourseDTO, UpdateCourseDTO } from '@/courses/dtos/courses.dto';
 import { Repository, ILike, In } from 'typeorm';
@@ -90,17 +91,27 @@ export default class CoursesService implements IService {
   }
   async updateCourse({
     where,
-    data: { cover_image, ...rest },
+    data: { ...rest },
   }: UpdateCourseDTO): Promise<Course> {
     const course = await this.courseRepository.findOne({ where });
     if (!course) {
       throw new CustomError('코스가 존재하지 않습니다.');
     }
     for (const [key, val] of Object.entries(rest)) course[key] = val;
-    if (cover_image) {
-      // s3에서 기존 데이터 삭제 요청
-      course.cover_image = cover_image;
+    const result = await this.courseRepository.save(course);
+    return result;
+  }
+  async updateCourseWithCoverImage({
+    where,
+    data: { cover_image, ...rest },
+  }: UpdateCourseWithCoverImageDTO): Promise<Course> {
+    const course = await this.courseRepository.findOne({ where });
+    if (!course) {
+      throw new CustomError('코스가 존재하지 않습니다.');
     }
+    for (const [key, val] of Object.entries(rest)) course[key] = val;
+    course.cover_image = cover_image;
+
     const result = await this.courseRepository.save(course);
     return result;
   }

--- a/src/courses/services/lectures.service.ts
+++ b/src/courses/services/lectures.service.ts
@@ -114,7 +114,7 @@ export default class LecturesService implements IService {
           });
 
           if (!lecture) throw new CustomError('강의가 존재하지 않습니다.');
-          lecture.order = i;
+          lecture.order = i + 1;
           await transactionalEntityManager.save(lecture);
         }
       },

--- a/src/courses/services/lectures.service.ts
+++ b/src/courses/services/lectures.service.ts
@@ -3,13 +3,15 @@ import { CustomError, IService } from '@/commons/interfaces';
 import { Repository } from 'typeorm';
 import {
   CreateLectureDTO,
+  CreateLectureWithVideoUrlDTO,
   DeleteLectureDTO,
   DeleteLecturesDTO,
   FindLectureByIdDTO,
   FindLecturesByChapterIdDTO,
   FindTempLecturesByCourseIdDTO,
-  UpdateChapterlessLecutreDTO,
   UpdateLectureDTO,
+  UpdateLectureWithVideoUrlDTO,
+  UpdateLectureOrdersDTO,
 } from '../dtos/lectures.dto';
 import Lecture from '../entities/lecture.entity';
 
@@ -22,7 +24,7 @@ export default class LecturesService implements IService {
 
   async findTempLecturesByCourseId({
     where,
-    select
+    select,
   }: FindTempLecturesByCourseIdDTO): Promise<Lecture[]> {
     const result = await this.lectureRepository.find({
       where: { ...where, chapter_id: 0 },
@@ -52,8 +54,18 @@ export default class LecturesService implements IService {
     if (!result) throw new CustomError('강의가 존재하지 않습니다.');
     return result;
   }
-  
+
   async createLecture({ where, data }: CreateLectureDTO): Promise<Lecture> {
+    const result = await this.lectureRepository.save(
+      this.lectureRepository.create({ ...where, ...data }),
+    );
+    return result;
+  }
+
+  async createLectureWithVideoUrl({
+    where,
+    data,
+  }: CreateLectureWithVideoUrlDTO): Promise<Lecture> {
     const result = await this.lectureRepository.save(
       this.lectureRepository.create({ ...where, ...data }),
     );
@@ -62,35 +74,52 @@ export default class LecturesService implements IService {
 
   async updateLecutre({
     where,
-    data: { video_url, ...rest },
+    data: { ...rest },
   }: UpdateLectureDTO): Promise<Lecture> {
     const lecture = await this.lectureRepository.findOne({ where });
     if (!lecture) throw new CustomError('강의가 존재하지 않습니다.');
 
     for (const [key, val] of Object.entries(rest)) lecture[key] = val;
-    if (video_url) {
-      // 기존의 영상 데이터를 s3에서 제거 요청
-      lecture.video_url = video_url;
-    }
 
     const result = await this.lectureRepository.save(lecture);
     return result;
   }
 
-  async updateChapterlessLectures({
-    chapter_id,
-    teacher_id
-  }: UpdateChapterlessLecutreDTO): Promise<Lecture[]> {
-    const lectures = await this.lectureRepository.find({
-      where: {chapter_id, teacher_id}
-    });
-    
-    for (const [_, lecture] of Object.entries(lectures)) {
-      lecture.chapter_id = 0;
-    }
+  async updateLecutreWithVideoUrl({
+    where,
+    data: { video_url, ...rest },
+  }: UpdateLectureWithVideoUrlDTO): Promise<Lecture> {
+    const lecture = await this.lectureRepository.findOne({ where });
+    if (!lecture) throw new CustomError('강의가 존재하지 않습니다.');
 
-    const result = await this.lectureRepository.manager.save(lectures);
+    for (const [key, val] of Object.entries(rest)) lecture[key] = val;
+    lecture.video_url = video_url;
+
+    const result = await this.lectureRepository.save(lecture);
     return result;
+  }
+
+  async updateLectureOrders({
+    teacher_id,
+    data,
+  }: UpdateLectureOrdersDTO): Promise<number[]> {
+    const lectures = data.lectures;
+
+    await this.lectureRepository.manager.transaction(
+      'SERIALIZABLE',
+      async (transactionalEntityManager) => {
+        for (let i = 0; i < lectures.length; i++) {
+          const lecture = await this.lectureRepository.findOne({
+            where: { teacher_id, id: lectures[i] },
+          });
+
+          if (!lecture) throw new CustomError('강의가 존재하지 않습니다.');
+          lecture.order = i;
+          await transactionalEntityManager.save(lecture);
+        }
+      },
+    );
+    return lectures;
   }
 
   async deleteLecture(dto: DeleteLectureDTO): Promise<DeleteLectureDTO> {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -69,9 +69,7 @@ export default class UsersController implements IController {
   }
 
   getRouter() {
-    this.router.use(JwtGuard);
-
-    this.router.get('/profile', (req, res) =>
+    this.router.get('/profile', JwtGuard, (req, res) =>
       this.getApi(async () => {
         const user = new JwtPayload(req.user as Express.User);
         await validateOrReject(user, { whitelist: true });
@@ -102,7 +100,7 @@ export default class UsersController implements IController {
       ),
     );
 
-    this.router.post('/:user_id/delete', (req, res) =>
+    this.router.post('/:user_id/delete', JwtGuard, (req, res) =>
       this.getApi(async () => {
         const user = new JwtPayload(req.user as Express.User);
         await validateOrReject(user, { whitelist: true });
@@ -132,6 +130,7 @@ export default class UsersController implements IController {
 
     this.router.post(
       '/:user_id/role/:role/update',
+      JwtGuard,
       RoleGuard(UserRole.Admin),
       (req, res) =>
         this.getApi(async () => {


### PR DESCRIPTION
- [ o ] 요청에 보낸 리스트의 아이디 집합과 코스에 존재하는 챕터 아이디 집합이 완전히 동일해야 함
- [ o ] 요청 중에 오류가 나서 중단되면 일부 어떻게 롤백할지 -> transaction을 사용
- [ o ] 해당 요청을 실행할 api 추가 - /:course_id/chapters/update -> 한 코스의 렉처 order 한꺼번에 수정
- [ o ] 해당 요청을 실행할 api 추가 - /:course_id/chapters/:chapter_id/lectures/update -> 한 챕터의 렉처 order 한꺼번에 수정
- [ o ] 챕터 지울 때 lecture가 있으면 못지우는 걸로 수정, lecture가 존재하는 chapter는 삭제 요청 거부
- [ o ] 챕터 하나 변경할 때 order는 변경 할 수 없고, title만 변경할 수 있다.
- [ o ] lecture 변경할 때 order는 변경할 수 없지만, chapter_id는 변경 될 수 있다. 
        이때 lecture의 order는 변경된 chapter의 마지막이 된다. 특히 lecture의 변경에서는 숫자가 모두 문자열로 보내진다.
- [ o ] chapter나 lecture 하나 create 할때 order 1부터 시작을 0부터 시작으로 바꾸기 -> order 수정시 배열 0부터 시작해서 편하
- [ o ] lecture update에서 select {video_url: true} 부분 및 불명확한 변수들 리팩토링하기 -> 파일 업로드 관련 api 모두 리팩토링
- [ o ] 위에 사항 관련해서 s3 데이터가 잘 지워지는 지 다시 확인
- [ o ] lecture 생성할 때 해당 course에 존재하지 않는 chpater_id를 넣어도 lecture가 생성되는 bug fix
- [ o ] user controller전체에 jwtMiddleware적용되어있는거 수정하고 /user/userid를 public으로

---

- [ o ] order를 0부터 시작이 아닌 1부터 시작하는 것으로 수정 → 챕터 or 렉처 생성시, 챕터 or 렉처 order list 변경시, 렉처를 다른 챕터로 옮길 시

---

- [ o ] sonar cloud bug fix